### PR TITLE
Update Deploy to Bluemix URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Diamond Demo
 ##Deploying the demo##
 To deploy to Bluemix simply use the button below then follow the instructions. This will generate the NodeJS server and the Blockchain service for you.
 
-[![Deploy to Bluemix](https://bluemix.net/deploy/button.png)](https://hub.jazz.net/deploy/index.html?repository=https://github.com/sethulekshmi/inf.git
+[![Deploy to Bluemix](https://bluemix.net/deploy/button.png)](https://bluemix.net/deploy?repository=https://github.com/sethulekshmi/inf.git


### PR DESCRIPTION
The `hub.jazz.net/deploy` page is going away soon. Its replacement is https://bluemix.net/deploy
which uses DevOps Toolchains to deploy the application.

This pull request updates the URL in the README file.